### PR TITLE
docs: add all-contributors config and updated readme

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,172 @@
+{
+  "projectName": "kcdraidgroup",
+  "projectOwner": "kcdraidgroup",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "none",
+  "skipCi": true,
+  "contributorsPerLine": 7,
+  "types": {
+    "raider": {
+      "symbol": "⚔",
+      "description": "Raider",
+      "link": "#raids-crossed_swords"
+    }
+  },
+  "contributors": [
+    {
+      "login": "JacobMGEvans",
+      "name": "Jacob M-G Evans",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/27247160?v=4",
+      "profile": "https://dev.to/jacobmgevans",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "nobrayner",
+      "name": "Braydon Hall",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/40751395?v=4",
+      "profile": "https://github.com/nobrayner",
+      "contributions": [
+        "raider",
+        "ideas",
+        "content"
+      ]
+    },
+    {
+      "login": "juhanakristian",
+      "name": "Juhana Jauhiainen",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/544386?v=4",
+      "profile": "https://github.com/juhanakristian",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "merodiro",
+      "name": "Amr A.Mohammed",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/17033502?v=4",
+      "profile": "https://github.com/merodiro",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "tigerabrodi",
+      "name": "Tiger Abrodi",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/49603590?v=4",
+      "profile": "https://tigerabrodi.dev/",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "marcosvega91",
+      "name": "Marco Moretti",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/5365582?v=4",
+      "profile": "https://github.com/marcosvega91",
+      "contributions": [
+        "raider"
+      ]
+    },
+    {
+      "login": "Aprillion",
+      "name": "Peter Hozák",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1087670?v=4",
+      "profile": "http://peter.hozak.info/",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "TheGallery",
+      "name": "Joseph Psychas",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/3214876?v=4",
+      "profile": "https://github.com/TheGallery",
+      "contributions": [
+        "raider"
+      ]
+    },
+    {
+      "login": "proful",
+      "name": "Proful Sadangi",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/354596?v=4",
+      "profile": "https://github.com/proful",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "tsuki42",
+      "name": "Sudhanshu",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/22864071?v=4",
+      "profile": "https://github.com/tsuki42",
+      "contributions": [
+        "raider"
+      ]
+    },
+    {
+      "login": "mpeyper",
+      "name": "Michael Peyper",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/23029903?v=4",
+      "profile": "https://github.com/mpeyper",
+      "contributions": [
+        "raider",
+        "ideas",
+        "infra"
+      ]
+    },
+    {
+      "login": "emma-r-slight",
+      "name": "Emma ",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/60733989?v=4",
+      "profile": "https://github.com/emma-r-slight",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    },
+    {
+      "login": "ziedtouibi",
+      "name": "Zied.Touibi",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/15978090?v=4",
+      "profile": "https://twitter.com/ZiedTouibi",
+      "contributions": [
+        "raider",
+        "ideas",
+        "design"
+      ]
+    },
+    {
+      "login": "kiranjd",
+      "name": "Kiran Jd",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/25822851?v=4",
+      "profile": "https://github.com/kiranjd",
+      "contributions": [
+        "raider"
+      ]
+    },
+    {
+      "login": "codyarose",
+      "name": "Cody Rose",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/35306025?v=4",
+      "profile": "https://github.com/codyarose",
+      "contributions": [
+        "raider",
+        "ideas"
+      ]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+package-lock=false
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ### `Find Target` :dart: `Communicate` :satellite: `Raid` :crossed_swords: `Push Code` :tada:
 
+[![All Contributors](https://img.shields.io/github/all-contributors/kcdraidgroup/kcdraidgroup?color=orange&style=flat-square)](#contributors)
+
 The OSS Raid Group is what happens when you combine MMORPGs, Programming, and Open Source Software - a group dedicated to defeating the Raid Bosses of OSS!
 
 For those who aren't aware of these 'gamer' terms, and even those that are; here are the definitions we use when operating as a Raid Group.
@@ -71,3 +73,41 @@ When participating in a Raid, use the following steps.
 
 
 [discord]: https://kcd.im/discord
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://dev.to/jacobmgevans"><img src="https://avatars1.githubusercontent.com/u/27247160?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jacob M-G Evans</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-JacobMGEvans" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/nobrayner"><img src="https://avatars2.githubusercontent.com/u/40751395?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Braydon Hall</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-nobrayner" title="Ideas, Planning, & Feedback">🤔</a> <a href="#content-nobrayner" title="Content">🖋</a></td>
+    <td align="center"><a href="https://github.com/juhanakristian"><img src="https://avatars1.githubusercontent.com/u/544386?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Juhana Jauhiainen</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-juhanakristian" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/merodiro"><img src="https://avatars1.githubusercontent.com/u/17033502?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Amr A.Mohammed</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-merodiro" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://tigerabrodi.dev/"><img src="https://avatars1.githubusercontent.com/u/49603590?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tiger Abrodi</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-tigerabrodi" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/marcosvega91"><img src="https://avatars2.githubusercontent.com/u/5365582?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marco Moretti</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a></td>
+    <td align="center"><a href="http://peter.hozak.info/"><img src="https://avatars0.githubusercontent.com/u/1087670?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Peter Hozák</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-Aprillion" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/TheGallery"><img src="https://avatars1.githubusercontent.com/u/3214876?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joseph Psychas</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a></td>
+    <td align="center"><a href="https://github.com/proful"><img src="https://avatars2.githubusercontent.com/u/354596?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Proful Sadangi</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-proful" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/tsuki42"><img src="https://avatars2.githubusercontent.com/u/22864071?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sudhanshu</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a></td>
+    <td align="center"><a href="https://github.com/mpeyper"><img src="https://avatars0.githubusercontent.com/u/23029903?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Michael Peyper</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-mpeyper" title="Ideas, Planning, & Feedback">🤔</a> <a href="#infra-mpeyper" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
+    <td align="center"><a href="https://github.com/emma-r-slight"><img src="https://avatars0.githubusercontent.com/u/60733989?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Emma </b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-emma-r-slight" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://twitter.com/ZiedTouibi"><img src="https://avatars3.githubusercontent.com/u/15978090?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Zied.Touibi</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-ziedtouibi" title="Ideas, Planning, & Feedback">🤔</a> <a href="#design-ziedtouibi" title="Design">🎨</a></td>
+    <td align="center"><a href="https://github.com/kiranjd"><img src="https://avatars2.githubusercontent.com/u/25822851?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kiran Jd</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/codyarose"><img src="https://avatars1.githubusercontent.com/u/35306025?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cody Rose</b></sub></a><br /><a href="#raids-crossed_swords" title="Raider">⚔</a> <a href="#ideas-codyarose" title="Ideas, Planning, & Feedback">🤔</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kcdraidgroup",
+  "private": true,
+  "description": "Find Target 🎯 Communicate 📡 Raid ⚔️ Push Code 🎉",
+  "license": "UNLICENSED",
+  "repository": "https://github.com/kcdraidgroup/kcdraidgroup.git",
+  "scripts": {
+    "contributors:add": "all-contributors add",
+    "contributors:generate": "all-contributors generate"
+  },
+  "devDependencies": {
+    "all-contributors-cli": "^6.19.0"
+  }
+}


### PR DESCRIPTION
Adding initial `all-contributors` config for consideration.  As discussed with @nobrayner, I've added a custom contribution type call `raider` that can be used to highlight any participants of current or previous raids.

This setup is compatible with the `all-contributors` bot if we want to set that up too, but it will only work for comments from within this repo.  I think it's worthwhile still having so adding non-raid contributions a bit easier.

We were also discussing the idea of having out own automation to update the contributors list with raiders from commits/PRs to the raid repos.  That would be as possible by having the automation run the `contributors:add` script with their username and the `raider` type, e.g. `npm run contributors:add -- mpeyper raider`, then commit the changes.

You can see the pretty version of the README [here](https://github.com/kcdraidgroup/kcdraidgroup/tree/docs/all-contributors), but note that the badge won't work until the config is in the master branch.

Also, the contributions added in this PR are my best guess what they should be based on the `react-hooks-testing-library` and `hospital-run` raid, the website repo, this repo and discord.  I tried to match the github users to the regular crowd in discord, but I may have missed some people. Please feel free to update this branch with new or changed contributions or let me know what they should be and I can update it.  I know @JacobMGEvans's tweet said 25+ contributors on the `hospital-run` raid, but I struggled to find them all in the PRs and issues or [the raid repo](https://github.com/kcdraidgroup/hospitalrun-frontend) (there was lots to look through so I might have just missed them though).